### PR TITLE
feat(tui): implement configurable glamour theme system

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,9 @@ style:
   theme: ./themes/my-custom-theme.json
 ```
 
-The border color will automatically adapt to use the theme's H1 background color unless explicitly overridden with `border_color`.
+The border color will automatically adapt to use the theme's H1 background color unless explicitly overridden with `border_color`.o
+
+For more info on how to create custom styles, you can refer to [Glamour's](https://github.com/charmbracelet/glamour/tree/master/styles) documentation.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A terminal-based presentation tool that creates beautiful presentations from mar
   - Flip effects
 - **Hot reload**: Live reloading of presentation files during editing with the `-w` flag
 - **Customizable styling**: Configure borders, colors, and layouts via YAML front matter
+- **Theme support**: Choose from built-in Glamour themes or load custom JSON theme files
 - **Flexible layouts**: Center, align, and position content with various layout options
 - **Simple navigation**: Intuitive keyboard controls for presentation flow (vim style btw)
 
@@ -87,10 +88,20 @@ style:
   border: rounded
   border_color: "#9999CC"
   layout: center
+  theme: dracula
 ---
 
 # Third Slide
-This slide has custom styling
+This slide has custom styling with Dracula theme
+
+----
+---
+style:
+  theme: /path/to/custom-theme.json
+---
+
+# Fourth Slide
+This slide uses a custom JSON theme file
 ```
 
 ### Available Transitions
@@ -108,12 +119,39 @@ You can customize each slide's appearance using the style configuration:
 
 ```yaml
 style:
-  border: rounded      # Border style: normal, rounded, double, thick, hidden, block
-  border_color: "#FF0000"  # Hex color for border
-  layout: center       # Layout positioning: center, left, right, top, bottom
+  border: rounded          # Border style: normal, rounded, double, thick, hidden, block
+  border_color: "#FF0000"  # Hex color for border (or "default" for theme-based color)
+  layout: center           # Layout positioning: center, left, right, top, bottom
+  theme: dracula           # Theme name or path to custom JSON theme file
 ```
 
 Layout can also be specified as a combination: `layout: center,right`
+
+### Theme Support
+
+Kyma supports both built-in Glamour themes and custom JSON theme files:
+
+#### Built-in Themes
+
+- `ascii` - ASCII-only styling
+- `auto` - Automatically detected theme
+- `dark` - Dark theme (default)
+- `dracula` - Dracula color scheme
+- `tokyo-night` (or `tokyonight`) - Tokyo Night theme
+- `light` - Light theme
+- `notty` - Plain text styling
+- `pink` - Pink color scheme
+
+#### Custom JSON Themes
+
+You can create custom themes by providing a path to a JSON file that follows the Glamour `StyleConfig` format. If the theme name doesn't match a built-in theme, Kyma will attempt to load it as a JSON file:
+
+```yaml
+style:
+  theme: ./themes/my-custom-theme.json
+```
+
+The border color will automatically adapt to use the theme's H1 background color unless explicitly overridden with `border_color`.
 
 ## Contributing
 
@@ -140,7 +178,8 @@ All contributions are welcome! If you're planning a significant change or you're
 ## Roadmap
 
 - Add support for more style options like text color and background color
-- Allow choosing from any glamour themes
+- ~~Allow choosing from any glamour themes~~ ✅ **Done!**
+- ~~Support for custom JSON theme files~~ ✅ **Done!**
 - Create grid-based slide layouts with transitions for each pane  
 - Add more transition effects
 - Support image rendering in terminals (e.g., via the Kitty protocol)

--- a/internal/tui/slide.go
+++ b/internal/tui/slide.go
@@ -14,7 +14,7 @@ type Slide struct {
 	Data             string
 	Prev             *Slide
 	Next             *Slide
-	Style            lipgloss.Style
+	Style            SlideStyle
 	ActiveTransition transitions.Transition
 	Properties       Properties
 
@@ -45,7 +45,13 @@ func (s Slide) View() string {
 func (s Slide) view() string {
 	var b strings.Builder
 
-	out, err := glamour.Render(s.Data, "dark")
+	themeName := "dark"
+
+	if s.Style.Theme.Name != "" {
+		themeName = s.Style.Theme.Name
+	}
+
+	out, err := glamour.Render(s.Data, themeName)
 	if err != nil {
 		b.WriteString("\n\n" + lipgloss.NewStyle().
 			Foreground(lipgloss.Color("9")). // Red
@@ -56,12 +62,12 @@ func (s Slide) view() string {
 	if s.ActiveTransition != nil && s.ActiveTransition.Animating() {
 		direction := s.ActiveTransition.Direction()
 		if direction == transitions.Backwards {
-			b.WriteString(s.ActiveTransition.View(s.Next.View(), s.Style.Render(out)))
+			b.WriteString(s.ActiveTransition.View(s.Next.View(), s.Style.LipGlossStyle.Render(out)))
 		} else {
-			b.WriteString(s.ActiveTransition.View(s.Prev.View(), s.Style.Render(out)))
+			b.WriteString(s.ActiveTransition.View(s.Prev.View(), s.Style.LipGlossStyle.Render(out)))
 		}
 	} else {
-		b.WriteString(s.Style.Render(out))
+		b.WriteString(s.Style.LipGlossStyle.Render(out))
 	}
 	return b.String()
 }

--- a/internal/tui/style.go
+++ b/internal/tui/style.go
@@ -158,7 +158,7 @@ func getTheme(theme string) GlamourTheme {
 		return GlamourTheme{Style: styles.DarkStyleConfig, Name: "dark"}
 	case "dracula":
 		return GlamourTheme{Style: styles.DraculaStyleConfig, Name: "dracula"}
-	case "tokyo-night":
+	case "tokyo-night", "tokyonight":
 		return GlamourTheme{Style: styles.TokyoNightStyleConfig, Name: "tokyo-night"}
 	case "light":
 		return GlamourTheme{Style: styles.LightStyleConfig, Name: "light"}

--- a/internal/tui/style.go
+++ b/internal/tui/style.go
@@ -1,7 +1,9 @@
 package tui
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/charmbracelet/glamour/ansi"
@@ -150,23 +152,32 @@ func getLayoutPosition(p string) (lipgloss.Position, error) {
 	}
 }
 
+const (
+	AsciiStyle      = "ascii"
+	AutoStyle       = "auto"
+	DarkStyle       = "dark"
+	DraculaStyle    = "dracula"
+	TokyoNightStyle = "tokyo-night"
+	LightStyle      = "light"
+	NoTTYStyle      = "notty"
+	PinkStyle       = "pink"
+)
+
 func getTheme(theme string) GlamourTheme {
-	switch theme {
-	case "ascii":
-		return GlamourTheme{Style: styles.ASCIIStyleConfig, Name: "ascii"}
-	case "dark":
-		return GlamourTheme{Style: styles.DarkStyleConfig, Name: "dark"}
-	case "dracula":
-		return GlamourTheme{Style: styles.DraculaStyleConfig, Name: "dracula"}
-	case "tokyo-night", "tokyonight":
-		return GlamourTheme{Style: styles.TokyoNightStyleConfig, Name: "tokyo-night"}
-	case "light":
-		return GlamourTheme{Style: styles.LightStyleConfig, Name: "light"}
-	case "notty":
-		return GlamourTheme{Style: styles.NoTTYStyleConfig, Name: "notty"}
-	case "pink":
-		return GlamourTheme{Style: styles.PinkStyleConfig, Name: "pink"}
-	default:
-		return GlamourTheme{Style: styles.DarkStyleConfig, Name: "dark"}
+	style, ok := styles.DefaultStyles[theme]
+	if !ok {
+		jsonBytes, err := os.ReadFile(theme)
+		if err != nil {
+			return GlamourTheme{Style: styles.DarkStyleConfig, Name: "dark"}
+		}
+
+		var customStyle ansi.StyleConfig
+		if err := json.Unmarshal(jsonBytes, &customStyle); err != nil {
+			return GlamourTheme{Style: styles.DarkStyleConfig, Name: "dark"}
+		}
+
+		return GlamourTheme{Style: customStyle, Name: theme}
 	}
+
+	return GlamourTheme{Style: *style, Name: theme}
 }

--- a/internal/tui/style.go
+++ b/internal/tui/style.go
@@ -152,17 +152,6 @@ func getLayoutPosition(p string) (lipgloss.Position, error) {
 	}
 }
 
-const (
-	AsciiStyle      = "ascii"
-	AutoStyle       = "auto"
-	DarkStyle       = "dark"
-	DraculaStyle    = "dracula"
-	TokyoNightStyle = "tokyo-night"
-	LightStyle      = "light"
-	NoTTYStyle      = "notty"
-	PinkStyle       = "pink"
-)
-
 func getTheme(theme string) GlamourTheme {
 	style, ok := styles.DefaultStyles[theme]
 	if !ok {

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -40,17 +40,8 @@ var keys = keyMap{
 
 const Fps = 60
 
-func style(width, height int, extra StyleConfig) lipgloss.Style {
-	borderColor := "#9999CC" // Blueish
-	if extra.BorderColor != "" {
-		borderColor = extra.BorderColor
-	}
-
-	return extra.Layout.
-		Border(extra.Border).
-		BorderForeground(lipgloss.Color(borderColor)).
-		Width(width - 4).
-		Height(height - 2)
+func style(width, height int, config StyleConfig) SlideStyle {
+	return config.ApplyStyle(width, height)
 }
 
 type model struct {


### PR DESCRIPTION
### TLDR
Add support for configurable markdown themes with dynamic border coloring and custom JSON theme file support.

## Change Summary

#### Added Features:
1. **Theme Support in YAML Configuration**:
   - Added `theme` field to `StyleConfig` for specifying built-in themes or custom JSON files
   - Support for both built-in Glamour themes and custom JSON theme files
   - Automatic border color adaptation from theme's H1 background color

2. **Built-in Theme Support**:
   - `ascii` - ASCII-only styling
   - `auto` - Automatically detected theme  
   - `dark` - Dark theme (default)
   - `dracula` - Dracula color scheme
   - `tokyo-night` (or `tokyonight`) - Tokyo Night theme
   - `light` - Light theme
   - `notty` - Plain text styling
   - `pink` - Pink color scheme

3. **Custom JSON Theme Files**:
   - Load custom themes from JSON files following Glamour `StyleConfig` format
   - File path resolution for theme files
   - Graceful fallback to dark theme on invalid files

#### Code Changes:
1. **In `internal/tui/style.go`**:
   - **New Types**:
     - `SlideStyle`: Combines lipgloss styling with glamour theme configuration
     - `GlamourTheme`: Wraps theme name and ansi style configuration
   - **New Functions**:
     - `ApplyStyle()`: Centralizes style application logic with theme-aware border coloring
     - `getTheme()`: Dynamic theme resolution supporting both built-in themes and JSON files
   - **Enhanced `StyleConfig`**: Added `Theme` field for YAML configuration
   - **Updated `UnmarshalYAML()`**: Parse theme configuration from YAML front matter
   - **Smart Border Colors**: Uses theme's H1 background color when `border_color` is "default" or unspecified

2. **In `internal/tui/slide.go`**:
   - Updated `Slide.Style` field type from `lipgloss.Style` to `SlideStyle`
   - Replaced hardcoded "dark" theme with dynamic theme selection in `view()`
   - Modified render calls to use `Style.LipGlossStyle.Render()` for compatibility

3. **In `internal/tui/tui.go`**:
   - Simplified `style()` function to delegate to `StyleConfig.ApplyStyle()`
   - Removed duplicate border color logic

#### Theme Resolution Logic:
- **Built-in Themes**: Uses `styles.DefaultStyles` map for efficient lookup
- **Custom JSON Files**: Attempts to read and unmarshal JSON when theme name doesn't match built-in themes
- **Fallback Strategy**: Gracefully falls back to dark theme for invalid themes or file read errors
- **Alias Support**: Supports both `tokyo-night` and `tokyonight` naming conventions

#### Documentation Updates:
- Added theme support to main features list
- Theme configuration examples in presentation format
- Documentation of all built-in themes with descriptions
- Custom JSON theme file usage instructions
- Updated style configuration section with theme options
- Marked completed theme roadmap items as done
