### PR TITLE
feat:  add quick nav keybinds

### DIFF
--- a/internal/tui/slide.go
+++ b/internal/tui/slide.go
@@ -10,7 +10,6 @@ import (
 	"github.com/museslabs/kyma/internal/tui/transitions"
 )
 
-
 type Slide struct {
 	Data             string
 	Prev             *Slide
@@ -63,9 +62,17 @@ func (s Slide) view() string {
 	if s.ActiveTransition != nil && s.ActiveTransition.Animating() {
 		direction := s.ActiveTransition.Direction()
 		if direction == transitions.Backwards {
-			b.WriteString(s.ActiveTransition.View(s.Next.View(), s.Style.LipGlossStyle.Render(out)))
+			if s.Next == nil {
+				panic("backwards transition at the last slide")
+			} else {
+				b.WriteString(s.ActiveTransition.View(s.Next.View(), s.Style.LipGlossStyle.Render(out)))
+			}
 		} else {
-			b.WriteString(s.ActiveTransition.View(s.Prev.View(), s.Style.LipGlossStyle.Render(out)))
+			if s.Prev != nil {
+				b.WriteString(s.ActiveTransition.View(s.Prev.View(), s.Style.LipGlossStyle.Render(out)))
+			} else {
+				b.WriteString(s.Style.LipGlossStyle.Render(out))
+			}
 		}
 	} else {
 		b.WriteString(s.Style.LipGlossStyle.Render(out))

--- a/internal/tui/slide.go
+++ b/internal/tui/slide.go
@@ -72,3 +72,19 @@ func (s Slide) view() string {
 	}
 	return b.String()
 }
+
+func (s *Slide) First() *Slide {
+	current := s
+	for current.Prev != nil {
+		current = current.Prev
+	}
+	return current
+}
+
+func (s *Slide) Last() *Slide {
+	current := s
+	for current.Next != nil {
+		current = current.Next
+	}
+	return current
+}

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -11,9 +11,11 @@ import (
 )
 
 type keyMap struct {
-	Quit key.Binding
-	Next key.Binding
-	Prev key.Binding
+	Quit   key.Binding
+	Next   key.Binding
+	Prev   key.Binding
+	Top    key.Binding
+	Bottom key.Binding
 }
 
 func (k keyMap) ShortHelp() []key.Binding {
@@ -36,6 +38,14 @@ var keys = keyMap{
 	Prev: key.NewBinding(
 		key.WithKeys("left", "h"),
 		key.WithHelp("<, h", "previous"),
+	),
+	Top: key.NewBinding(
+		key.WithKeys("home", "shift+up", "0"),
+		key.WithHelp("home, shift+up, 0", "top"),
+	),
+	Bottom: key.NewBinding(
+		key.WithKeys("end", "shift+down", "$"),
+		key.WithHelp("end, shift+down, $", "bottom"),
 	),
 }
 
@@ -116,6 +126,12 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				Start(m.width, m.height, transitions.Backwards)
 
 			return m, transitions.Animate(transitions.Fps)
+		} else if key.Matches(msg, m.keys.Top) {
+			m.slide = m.slide.First()
+			return m, nil
+		} else if key.Matches(msg, m.keys.Bottom) {
+			m.slide = m.slide.Last()
+			return m, nil
 		}
 	case transitions.FrameMsg:
 		slide, cmd := m.slide.Update()


### PR DESCRIPTION
### TLDR
Add keyboard shortcuts to jump to first/last slides and fix null pointer crashes.

## Change Summary

#### Added Features:
1. **New Navigation Methods in `slide.go`**:
   - `First()`: Navigate to the first slide in the presentation chain
   - `Last()`: Navigate to the last slide in the presentation chain

2. **New Key Bindings in `tui.go`**:
   - `Top`: Jump to first slide using `home`, `shift+up`, or `0` keys
   - `Bottom`: Jump to last slide using `end`, `shift+down`, or `$` keys

#### Code Changes:
1. **In `slide.go`**:
   - Added null pointer safety checks in `view()` method to prevent crashes during transitions
   - Added panic handling for backwards transitions at the last slide
   - Fixed potential null pointer dereference when `s.Prev` is nil during forward transitions
   - Removed extra blank line for cleaner formatting

2. **In `tui.go`**:
   - Extended `keyMap` struct with `Top` and `Bottom` key bindings
   - Added keyboard shortcuts mapping for quick navigation
   - Implemented navigation logic in `Update()` method using new slide methods

#### Documentation Updates:
1. **In `tui.go`**:
   - Updated help text to include new navigation shortcuts
