### PR TITLE
feat: add build automation and release infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Added by goreleaser init:
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,55 @@
+# This is an example .goreleaser.yml file with some sensible defaults.
+# Make sure to check the documentation at https://goreleaser.com
+
+# The lines below are called `modelines`. See `:help modeline`
+# Feel free to remove those if you don't want/need to use them.
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj
+
+version: 2
+
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod tidy
+    # you may remove this if you don't need go generate
+    - go generate ./...
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+    ldflags:
+      - -s -w -X github.com/museslabs/kyma/cmd.version={{.Version}}
+
+archives:
+  - formats: [tar.gz]
+    # this name template makes the OS and Arch compatible with the results of `uname`.
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    # use zip for windows archives
+    format_overrides:
+      - goos: windows
+        formats: [zip]
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+
+release:
+  footer: >-
+
+    ---
+
+    Released by [GoReleaser](https://github.com/goreleaser/goreleaser).

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Build script that injects version from git tag
+VERSION=$(git describe --tags --always)
+go build -ldflags "-s -w -X github.com/museslabs/kyma/cmd.version=$VERSION" -o kyma main.go
+
+echo "Binary: ./kyma" 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const version = "0.1.0"
+var version = "dev"
 
 var versionCmd = &cobra.Command{
 	Use:   "version",


### PR DESCRIPTION


### TLDR
Added GoReleaser config, build script with version injection, and dev versioning

## Change Summary

#### Added Features:
1. **New Build Script in `build.sh`**:
   - Automated build process that injects git tag version into binary using `-ldflags`
   - Uses `git describe --tags --always` to generate version string
   - Outputs optimized binary with `-s -w` flags for smaller size

2. **New Release Configuration in `.goreleaser.yaml`**:
   - Multi-platform build support (Linux, Windows, macOS)
   - Automated archive generation with proper naming conventions
   - Version injection via ldflags during GoReleaser builds
   - Changelog generation with commit filtering

#### Code Changes:
1. **In `cmd/version.go`**:
   - Changed `version` from constant to variable to allow runtime injection
   - Set default version to "dev" for local development builds

2. **In `.gitignore`**:
   - Added `dist/` directory to ignore GoReleaser build artifacts

### Context
This change establishes a proper release pipeline for the project. Local builds will show "dev" as the version, while builds through the build script or GoReleaser will inject the actual git tag version. This provides better version tracking and enables automated releases across multiple platforms.